### PR TITLE
Add configurable timeout system for TTS operations

### DIFF
--- a/.claude/config.example.json
+++ b/.claude/config.example.json
@@ -3,6 +3,7 @@
     "enabled": true,
     "provider": "pyttsx3",
     "text_length_limit": 2000,
+    "timeout": 120,
     "voices": {
       "macos": {
         "voice": "Alex",

--- a/.claude/hooks/utils/config.py
+++ b/.claude/hooks/utils/config.py
@@ -35,6 +35,7 @@ def load_config():
             "enabled": True,
             "provider": default_provider,
             "text_length_limit": 2000,
+            "timeout": 120,
             "voices": {
                 "macos": {
                     "voice": default_macos_voice,
@@ -158,6 +159,10 @@ def get_active_tts_provider():
 def get_text_length_limit():
     """Get the maximum text length for TTS processing."""
     return get_tts_config().get('text_length_limit', 2000)
+
+def get_tts_timeout():
+    """Get the timeout in seconds for TTS operations."""
+    return get_tts_config().get('timeout', 120)
 
 def get_voice_for_provider(provider):
     """Get the voice setting for a specific provider."""


### PR DESCRIPTION
## Summary
- Add configurable timeout setting to prevent TTS cutoffs on long responses
- Replace hardcoded 30-second timeout with user-configurable value (default: 120 seconds)
- Enhanced fallback handling with proper timeout reading from config

## Technical Changes
- Added `timeout` field to config.example.json with 120-second default
- Implemented `get_tts_timeout()` function in config.py
- Updated response_tts.py to use configurable timeout in subprocess calls
- Enhanced fallback functions to read timeout from config when available

## Test plan
- [x] Verify timeout configuration is read correctly
- [x] Test TTS with long responses (>550 characters) 
- [x] Confirm timeout errors display configured value
- [x] Validate fallback behavior when config unavailable

This resolves the TTS cutoff issue where responses were being truncated after ~550 characters due to the hardcoded 30-second timeout limit.

🤖 Generated with [Claude Code](https://claude.ai/code)